### PR TITLE
Use better supported method for decoding bytearray to string

### DIFF
--- a/code.py
+++ b/code.py
@@ -56,7 +56,7 @@ while True:
     message_bytes = struct.unpack_from(TINY_CODE_READER_MESSAGE_FORMAT, read_data, TINY_CODE_READER_MESSAGE_OFFSET)
 
     if message_length > 0:
-        message_string = bytearray(message_bytes)[0:message_length].decode("utf-8")
+        message_string = str(bytearray(message_bytes[:message_length]), 'utf-8')
         is_same = (message_string == last_message_string)
         last_message_string = message_string
         current_time = time.monotonic()


### PR DESCRIPTION
It [seems](https://github.com/adafruit/circuitpython/issues/384) not all SAMD21 based CircuitPython boards support `bytearray.decode`. I get a crash:
`'bytearray' object has no attribute 'decode'`
on a [CP Sapling](https://circuitpython.org/board/cp_sapling_m0_revb/) dev board.